### PR TITLE
Added preinstall hooks (pip install and shell scripts)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,6 +48,12 @@ jobs:
           $CONDA/bin/python -m pip install .
           conda config --add channels conda-forge
 
+      - name: Install empty conda env for test_utils.test_get_conda_python_executable
+        run: conda create -n foo python=3.8 -y
+
+      - name: Install daps-utils in the "main" user env for test_utils.test_get_pkg_spec
+        run: $CONDA/bin/python -m pip install git+https://github.com/nestauk/daps_utils@dev
+
       - name: Git config
         run: |
           git config --global user.email test@example.com

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
-  - repo: https://github.com/prettier/pre-commit
-    rev: v2.1.2
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v2.4.1
     hooks:
       - id: prettier
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -38,12 +38,12 @@ repos:
         args: ["-b", dev, "-b", master, "-b", main]
         pass_filenames: false
   - repo: https://github.com/psf/black
-    rev: stable
+    rev: 21.9b0
     hooks:
       - id: black
         language_version: python3
   - repo: https://github.com/pycqa/flake8
-    rev: 3.9.2
+    rev: 4.0.1
     hooks:
       - id: flake8
         name: flake8

--- a/metaflow_extensions/config/metaflow_config.py
+++ b/metaflow_extensions/config/metaflow_config.py
@@ -19,6 +19,8 @@ _suffix_list = ",".join(
         ".yaml",  # Config files
         ".md",  # E.g. when setup.py reads README.md
         ".txt",  # E.g. requirements.txt
+        ".sh",  # E.g. pre-install.sh
+        "VERSION",  # present in DAPS projects
     ]
 )
 DEFAULT_PACKAGE_SUFFIXES = from_conf("METAFLOW_DEFAULT_PACKAGE_SUFFIXES", _suffix_list)
@@ -52,3 +54,8 @@ def get_pinned_conda_libs(python_version: str) -> Dict[str, str]:
 # Defines root of a project for ProjectEnvironment
 _project_files = ["setup.py", "pyproject.toml"]
 PROJECT_FILES = from_conf("METAFLOW_PROJECT_FILES", _project_files)
+
+
+# Defines packages that should be pip installed prior to all execution
+_preinstall_pkgs = "daps-utils"
+PREINSTALL_PKGS = from_conf("METAFLOW_PREINSTALL_PKGS", _preinstall_pkgs).split(",")

--- a/metaflow_extensions/plugins/install_step_decorator.py
+++ b/metaflow_extensions/plugins/install_step_decorator.py
@@ -11,16 +11,11 @@ Implementation notes:
   every step, and as ProjectEnvironment is intended to replace the
   default environment, we may not always be in a project context.
 """
-import sys
-from pathlib import Path
-
 from metaflow.decorators import StepDecorator
 
 from metaflow_extensions.utils import (
-    local_pip_install,
-    running_in_local_env,
-    up_to_project_root,
-    upgrade_pip,
+    install_flow_project,
+    is_task_running_in_local_env,
 )
 
 
@@ -50,15 +45,9 @@ class InstallProjectStepDecorator(StepDecorator):
 
     def task_pre_step(self, *args):
         """If not running locally, install project package if one exists."""
-        if running_in_local_env():
+        if is_task_running_in_local_env():
             return
-
-        flow_path = Path(sys.argv[0])
-        project_root = up_to_project_root(flow_path)
-        if project_root:
-            upgrade_pip()  # Need newer features for install step
-            local_pip_install(project_root)
-
+        project_root = install_flow_project()
         if not project_root and self.attributes["fail_loudly"]:
             raise FileNotFoundError(
                 f"Could not find pip-installable file @ {project_root}"

--- a/metaflow_extensions/plugins/project_environment.py
+++ b/metaflow_extensions/plugins/project_environment.py
@@ -10,22 +10,127 @@ Implementation notes:
 import sys
 from itertools import filterfalse
 from pathlib import Path
+from typing import Callable
 
 import click
 from metaflow.metaflow_environment import MetaflowEnvironment
 from metaflow.plugins.conda.conda_environment import CondaEnvironment
+from metaflow.plugins.conda.conda_step_decorator import CondaStepDecorator
 
 from metaflow_extensions.utils import (
+    get_conda_python_executable,
+    get_pkg_spec,
+    install_flow_project,
     is_path_hidden,
+    pip_install,
+    platform_arch_mismatch,
     up_to_project_root,
+    upgrade_pip,
     walk,
     zip_stripped_root,
 )
+
+
+def bootstrap_wrapper(conda_env_bootstrap_commands):
+    """Concatenates {CondaEnvironment and ProjectEnvironment}.bootstrap_commands.
+
+    In the flow lifecycle this called directly before the conda step is
+    explicitly executed: in practice this occurs in metaflow's batch.py
+    (i.e. it is only executed on batch steps). There is some duplication with
+    the prepare_step_wrapper method in this module, which can be read in the
+    docstring therein.
+
+    Arguments:
+        conda_env_bootstrap_commands: CondaEnvironment method to be wrapped
+
+    Returns:
+        The wrapped function
+    """
+
+    def wrapped_bootstrap_commands(self, step_name):
+        cmds = conda_env_bootstrap_commands(self, step_name)
+        cmds += ProjectEnvironment.bootstrap_commands(self, step_name)
+        return cmds
+
+    return wrapped_bootstrap_commands
+
+
+def prepare_step_wrapper(conda_step_prepare_step_environment: Callable) -> Callable:
+    """Appends commands after CondaStepDecorator._prepare_step_environment execution.
+
+    In the flow lifecycle this is executed prior to steps being explicitly executed:
+    in practice this occurs in conda_step_decorator.package_init and
+    runtime_task_create, and it is only executed on local steps (i.e. not batch
+    steps). There is some duplication with the task_pre_step method in this
+    module as the bootstrap_commands method is executed
+    immediately prior to the batch runtime, and is never called locally.
+
+    In short, the difference between task_pre_step
+    and bootstrap_wrapper is that:
+
+      * prepare_step_wrapper patches the local conda environment only (it is unable to
+        patch the batch conda environment because different of architectures, e.g.
+        MacOS on local vs Linux on batch, although patching of the batch environment
+        is anyway inconsequential as it is reproduced from conda.dependencies anyway.)
+      * bootstrap_wrapper patches the batch conda env only, by definition.
+
+    Arguments:
+        conda_step_prepare_step_environment: CondaStepDecorator method to be wrapped
+
+    Returns:
+        The wrapped function
+    """
+
+    def wrapped_prepare_step_environment(self, *args, **kwargs):
+        from metaflow_extensions.config.metaflow_config import (
+            PREINSTALL_PKGS,
+            DEFAULT_ENVIRONMENT,
+        )
+
+        env_id = conda_step_prepare_step_environment(self, *args, **kwargs)
+        if DEFAULT_ENVIRONMENT != "project":
+            return env_id  # i.e. use default behaviour for non-project environments
+
+        # tl,dr; if this is a batch step, skip it, as package installation
+        #        for batch steps is done by bootstrap_wrapper, whereas
+        #        prepare_step_wrapper deals with local steps.
+        #
+        # Batch steps have a conda environment with an arch (Linux) that doesn't
+        # match the local arch (e.g. MacOS). In the "edge case" where the local
+        # arch and batch arch match (i.e. are both Linux) then no harm
+        # will be done by doubly installing the same packages, both here and
+        # with project_environment.bootstrap_wrapper
+        if platform_arch_mismatch(env_id):
+            return env_id
+
+        python_exec = get_conda_python_executable(env_id)
+        upgrade_pip(python_exec)  # Need newer features for install step
+
+        # Pre-install specified packages if the user has them
+        # installed in their local python env
+        for pkg_spec in filter(None, map(get_pkg_spec, PREINSTALL_PKGS)):
+            pip_install(python_exec, pkg_spec)
+
+        # Install the local project into the current conda env
+        install_flow_project(python_exec)
+        return env_id
+
+    return wrapped_prepare_step_environment
+
 
 # XXX - ProjectEnvironment.decospecs is never called if environment=conda!
 #       Patch it to add our decospecs too
 #       Awaiting fix in PR: https://github.com/Netflix/metaflow/pull/660
 CondaEnvironment.decospecs = lambda s: ("conda", *s.base_env.decospecs())
+
+# Force CondaEnvironment to pick up extra ProjectEnvironment.bootstrap_commands
+CondaEnvironment.bootstrap_commands = bootstrap_wrapper(
+    CondaEnvironment.bootstrap_commands
+)
+
+CondaStepDecorator._prepare_step_environment = prepare_step_wrapper(
+    CondaStepDecorator._prepare_step_environment
+)
 
 
 class ProjectEnvironment(MetaflowEnvironment):
@@ -73,3 +178,31 @@ class ProjectEnvironment(MetaflowEnvironment):
     def get_client_info(cls, *args):
         """Client information."""
         return "Local project environment (metaflow_extensions)"
+
+    def bootstrap_commands(self, step_name):
+        """Run before any step decorators are initialized."""
+        # Import encapsulated to avoid import errors
+        from metaflow_extensions.config.metaflow_config import PREINSTALL_PKGS
+
+        # Run any pre-install scripts
+        flow_name = Path(sys.argv[0]).stem
+        flow_dir = Path(sys.argv[0]).parent
+        preinstalls = (
+            "preinstall.sh",
+            f"preinstall-{flow_name}.sh",
+            f"preinstall-{flow_name}-{step_name}.sh",
+        )
+        preinstalls = list(
+            filter(lambda fname: (flow_dir / fname).exists(), preinstalls)
+        )
+        cmds = [f"chmod +x {fname} && ./{fname}" for fname in preinstalls]
+
+        # Pre-install specified packages if the user have them
+        # installed in their local python env
+        pip_install = f"{self.executable(step_name)} -m pip install --quiet"
+        for pkg_spec in filter(None, map(get_pkg_spec, PREINSTALL_PKGS)):
+            cmds += [
+                f"{pip_install} --upgrade pip",
+                f"{pip_install} {pkg_spec} 1> /dev/null",
+            ]
+        return cmds

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 metaflow>=2.4.1
+pip>=21.3.1
+sh
 flake8
 darglint
 pep8-naming

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,9 @@ strictness=short
 docstring_style=google
 
 [tool:pytest]
-markers = aws: AWS credentials required
-addopts = -vv -m "not aws"
+markers =
+    aws: AWS credentials required
+    ci_only: Only run in CI
+addopts = -vv -m "not aws and not ci_only"
 norecursedirs=
     myproject

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ import shutil
 from pathlib import Path
 
 import pytest
+import sh
 
 from metaflow_extensions.utils import local_pip_install
 from utils import remove_pkg  # noqa: I
@@ -15,6 +16,7 @@ def temporary_project_maker(tmpdir_factory, project_name):
     project_path = Path(__file__).parent / project_name
     temp = tmpdir_factory.mktemp("data-project")
     shutil.copytree(project_path, temp / project_name)
+    sh.git.init(temp)  # to support "daps-utils"-like projects
     yield temp
     shutil.rmtree(temp)
 
@@ -37,5 +39,6 @@ def temporary_duffproject(tmpdir_factory):
 def temporary_installed_project(temporary_project):
     """Install `{temporary_project}/myproject/setup.py`."""
     local_pip_install(f"{temporary_project}/myproject")
+    sh.git.init(temporary_project)  # to support "daps-utils"-like projects
     yield temporary_project
     remove_pkg("myproject")

--- a/tests/myproject/myproject/flows/batch_flow.py
+++ b/tests/myproject/myproject/flows/batch_flow.py
@@ -1,0 +1,44 @@
+import daps_utils  # This works on batch because of bootstrap_command
+from metaflow import batch, FlowSpec, step
+
+
+class BatchFlow(FlowSpec, daps_utils.DapsFlowMixin):
+    """Dummy batch flow for showing that bootstrap_command is working."""
+
+    @step
+    def start(self):
+        """Start the flow."""
+        self.next(self.a)
+
+    @step
+    def a(self):
+        """Prepare chunks for batching."""
+        self.items = [1]
+        self.next(self.b, foreach="items")
+
+    @batch(queue="job-queue-nesta-metaflow-test")
+    @step
+    def b(self):
+        """Show that daps_utils is installed, and that preinstall is run."""
+        self.something = self.input
+        # Show daps_utils is installed
+        print("non-conda batch task has installed", daps_utils.__version__)
+        # Show preinstall has run (it adds a file called 'special-batch-file')
+        from pathlib import Path
+
+        assert Path("special-batch-file").exists()
+        self.next(self.c)
+
+    @step
+    def c(self, inputs):
+        """Join the chunks."""
+        self.next(self.end)
+
+    @step
+    def end(self):
+        """Done."""
+        pass
+
+
+if __name__ == "__main__":
+    BatchFlow()

--- a/tests/myproject/myproject/flows/batch_flow_with_conda.py
+++ b/tests/myproject/myproject/flows/batch_flow_with_conda.py
@@ -1,0 +1,73 @@
+from pathlib import Path
+
+import daps_utils  # This works on batch because of bootstrap_command
+from metaflow import batch, conda, FlowSpec, step
+
+
+class BatchFlow(FlowSpec, daps_utils.DapsFlowMixin):
+    """Dummy batch flow for showing that bootstrap_command is working."""
+
+    @step
+    def start(self):
+        """Start the flow."""
+        self.next(self.a)
+
+    @step
+    def a(self):
+        """Prepare chunks for batching."""
+        self.items = [1]
+        self.next(self.b, foreach="items")
+
+    @batch(queue="job-queue-nesta-metaflow-test")
+    @step
+    def b(self):
+        """Show that daps_utils is installed, and that preinstall is run."""
+        self.something = self.input
+        # Show daps_utils is installed
+        print("non-conda lib daps_utils installed: ", daps_utils.__version__)
+
+        # Show preinstall has run (it adds a file called 'special-batch-file')
+        assert Path("special-batch-file").exists()
+        self.next(self.c)
+
+    @step
+    def c(self, inputs):
+        """Join the chunks."""
+        self.next(self.d)
+
+    @step
+    def d(self):
+        """Prepare more chunks for batching."""
+        self.items = [1]
+        self.next(self.e, foreach="items")
+
+    @conda(libraries={"sh": "1.14.2"})
+    @batch(queue="job-queue-nesta-metaflow-sandbox")
+    @step
+    def e(self):
+        """Show that daps_utils is also installed."""
+        # First show that we're in the env
+        import sh
+
+        self.something = self.input
+        print("conda specific lib sh installed: ", sh.__version__)
+
+        # Next show that daps_utils is not installed
+        print("non-conda lib daps_utils installed: ", daps_utils.__version__)
+
+        assert Path("special-batch-file").exists()
+        self.next(self.f)
+
+    @step
+    def f(self, inputs):
+        """Join the chunks."""
+        self.next(self.end)
+
+    @step
+    def end(self):
+        """Done."""
+        pass
+
+
+if __name__ == "__main__":
+    BatchFlow()

--- a/tests/myproject/myproject/flows/preinstall-batch_flow.sh
+++ b/tests/myproject/myproject/flows/preinstall-batch_flow.sh
@@ -1,0 +1,1 @@
+touch special-batch-file

--- a/tests/myproject/myproject/flows/preinstall-batch_flow_with_conda.sh
+++ b/tests/myproject/myproject/flows/preinstall-batch_flow_with_conda.sh
@@ -1,0 +1,1 @@
+touch special-batch-file

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1,14 +1,20 @@
 """Test a simple flow can import packages defined in it's environment."""
+from pathlib import Path
+
 import pytest
 
 from utils import ch_dir, run_flow  # noqa: I
 
-flow_name = "{}/myproject/myproject/flows/flow.py".format
+flow_name = lambda path, flow: Path(  # noqa
+    "{}/myproject/myproject/flows/{}.py".format(path, flow)
+)
 
 
-def test_runs_locally(temporary_installed_project):
+@pytest.mark.parametrize("flow", ["flow", "batch_flow"])
+def test_runs_locally(temporary_installed_project, flow):
     """Flow should run without `metaflow_extensions` if `myproject` pip installed."""
-    run_flow(flow_name(temporary_installed_project))
+    kwargs = {"datastore": "s3"} if flow.startswith("batch") else {}
+    run_flow(flow_name(temporary_installed_project, flow), **kwargs)
 
 
 def test_duff_project_runs_locally(temporary_duffproject):
@@ -18,24 +24,27 @@ def test_duff_project_runs_locally(temporary_duffproject):
     """
     with ch_dir(temporary_duffproject / "myduffproject"):
         proc = run_flow(
-            temporary_duffproject / "myduffproject/myduffproject/flows/duff_flow.py"
+            temporary_duffproject / "myduffproject/myduffproject/flows/duff_flow.py",
+            extend_pythonpath=False,
         )
     assert b"project environment did not find a root file" in proc.stdout
-    
-    
 
-def test_runs_conda(temporary_project):
+
+@pytest.mark.parametrize("flow", ["flow", "batch_flow", "batch_flow_with_conda"])
+def test_runs_conda(temporary_project, flow):
     """`flow.py` should run due to `LocalProject` default environment."""
+    kwargs = {"datastore": "s3"} if flow.startswith("batch") else {}
     with ch_dir(temporary_project / "myproject"):
-        run_flow(flow_name(temporary_project), environment="conda")
+        run_flow(flow_name(temporary_project, flow), environment="conda", **kwargs)
 
 
+@pytest.mark.parametrize("flow", ["flow"])
 @pytest.mark.aws
-def test_runs_batch(temporary_project):
+def test_runs_batch(temporary_project, flow):
     """`flow.py` should run due to `LocalProject` default environment."""
     with ch_dir(temporary_project / "myproject"):
         run_flow(
-            flow_name(temporary_project),
+            flow_name(temporary_project, flow),
             batch=True,
             metadata="service",
             datastore="s3",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,20 +1,29 @@
 import sys
 from pathlib import Path
+from unittest import mock
 from uuid import uuid4
 
 import pytest
 
 from metaflow_extensions.utils import (
+    _parse_pkg_spec,
+    get_conda_envs_directory,
+    get_conda_python_executable,
+    get_pkg_spec,
     has_project_file,
+    is_mflow_conda_environment,
     is_path_hidden,
-    running_in_local_env,
+    is_task_local,
+    is_task_running_in_local_env,
+    parse_subprocess_stdout,
+    platform_arch_mismatch,
     up_to_project_root,
     walk,
     zip_stripped_root,
 )
 from tests.conftest import MYPROJECT_PATH
-from utils import ch_dir  # noqa: I
 
+from utils import ch_dir, env  # noqa: I
 
 NONEXISTENT_PATH = Path(f"/{uuid4()}/foo/bar/baz")
 
@@ -41,11 +50,14 @@ def test_walk():
     expected_files_rel = [
         "setup.py",
         "myproject/__init__.py",
+        "myproject/__initplus__.py",
         "myproject/flows/flow.py",
+        "myproject/flows/batch_flow.py",
+        "myproject/flows/batch_flow_with_conda.py",
     ]
     expected_files_abs = set(str(MYPROJECT_PATH / file) for file in expected_files_rel)
     actual_files = set(walk(MYPROJECT_PATH, [".py"]))
-
+    print(actual_files)
     assert len(actual_files ^ expected_files_abs) == 0
 
 
@@ -80,18 +92,151 @@ def test_zip_stripped_root(root, strip_paths):
 @pytest.mark.parametrize(
     "argv,is_local",
     [
-        (["file", "conda"], False),
-        (["file", "batch"], False),
-        (["file", "conda:stuff"], False),
-        (["file", "batch:stuff"], False),
-        (["file", "prefix:conda"], True),
-        (["file", "prefix:batch"], True),
+        # True
+        (["file", "batch"], True),
+        (["file", "batch:stuff"], True),
+        (["file", "kubernetes"], True),
+        (["file", "kubernetes:stuff"], True),
+        (["file", "--environment", "conda"], True),
+        # False
+        (["file", "--with", "batch"], False),
+        (["file", "--with", "kubernetes"], False),
     ],
 )
-def test_running_in_local_env(argv, is_local):
+def test_is_task_local(argv, is_local):
     tmp = sys.argv.copy()
     try:
         sys.argv = argv
-        assert running_in_local_env() is is_local
+        assert is_task_local() is is_local
     finally:
         sys.argv = tmp
+
+
+@pytest.mark.parametrize(
+    "argv,default_env,is_conda",
+    [
+        # True
+        (["file", "--environment", "conda"], "local", True),
+        (["file", "--with", "conda"], "local", True),
+        (["file", "run"], "conda", True),
+        # False
+        (["file", "conda"], "local", False),
+        (["file", "batch"], "local", False),
+        (["file", "conda:stuff"], "local", False),
+        (["file", "batch:stuff"], "local", False),
+        (["file", "--environment", "other"], "local", False),
+    ],
+)
+def test_is_mflow_conda_environment(argv, default_env, is_conda):
+    tmp = sys.argv.copy()
+    with mock.patch("metaflow.metaflow_config.DEFAULT_ENVIRONMENT", default_env):
+        try:
+            sys.argv = argv
+            assert is_mflow_conda_environment() is is_conda
+        finally:
+            sys.argv = tmp
+
+
+@pytest.mark.parametrize(
+    "argv,is_local",
+    [
+        # True
+        (["file", "conda"], True),
+        (["file", "--flag", "conda"], True),
+        (["file", "--environment", "prefix:conda"], True),
+        (["file", "batch"], True),
+        (["file", "--flag", "batch"], True),
+        (["file", "--with", "prefix:batch"], True),
+        # False
+        (["file", "--environment", "conda"], False),
+        (["file", "--environment", "conda:stuff"], False),
+        (["file", "--with", "batch"], False),
+        (["file", "--with", "batch:stuff"], False),
+    ],
+)
+def test_is_task_running_in_local_env(argv, is_local):
+    tmp = sys.argv.copy()
+    try:
+        sys.argv = argv
+        assert is_task_running_in_local_env() is is_local
+    finally:
+        sys.argv = tmp
+
+
+@pytest.mark.ci_only
+def test_get_pkg_spec():
+    pkg_spec = get_pkg_spec("daps-utils")
+    git_path, _hash = pkg_spec.split("@")
+    assert git_path.endswith(
+        "nestauk/daps_utils"
+    )  # different forms depending on git/https scheme
+    assert len(_hash) == 40
+
+
+def test_daps_utils_spec_daps_utils_not_installed():
+    assert get_pkg_spec("something-that-doesnt-exist") is None
+
+
+@pytest.mark.ci_only
+def test_get_conda_python_executable():
+    python_exec = get_conda_python_executable("foo")
+    assert Path(python_exec).exists(), "Make sure conda env 'foo' exists"
+    assert python_exec.endswith("/python")
+
+
+@mock.patch("metaflow_extensions.utils.platform")
+@pytest.mark.parametrize(
+    "env_id,platform,is_mismatch",
+    [
+        ("foo_bar_linux32_abcd", "Linux", False),
+        ("foo_bar_linux64_abcd", "Linux", False),
+        ("foo_bar_osx32_abcd", "Linux", True),
+        ("foo_bar_osx64_abcd", "Linux", True),
+        ("foo_bar_linux32_abcd", "Darwin", True),
+        ("foo_bar_linux64_abcd", "Darwin", True),
+        ("foo_bar_osx32_abcd", "Darwin", False),
+        ("foo_bar_osx64_abcd", "Darwin", False),
+    ],
+)
+def test_platform_arch_mismatch_linux(mocked_platform, env_id, platform, is_mismatch):
+    mocked_platform.system.return_value = platform
+    assert platform_arch_mismatch(env_id) == is_mismatch
+
+
+@pytest.mark.parametrize(
+    "platform",
+    ["Windows", "MacOS", "ChromeOS", "Foo", "Bar"],
+)
+@mock.patch("metaflow_extensions.utils.platform")
+def test_platform_arch_mismatch_other_system(mocked_platform, platform):
+    mocked_platform.system.return_value = platform
+    for system in ["foo", "bar", "baz", "linux32", "linux64", "osx32", "osx64"]:
+        env_id = f"foo_bar_{system}_abcd"
+        with pytest.raises(ValueError):
+            platform_arch_mismatch(env_id)
+
+
+def test_parse_subprocess_stdout():
+    subprocess_output = mock.Mock()
+    subprocess_output.stdout = b"foo\nbar\nbaz"
+    assert list(parse_subprocess_stdout(subprocess_output)) == ["foo", "bar", "baz"]
+
+
+def test__parse_pkg_spec():
+    assert _parse_pkg_spec("foo @ git+https://path/to/foo.git") == (
+        "foo",
+        "git+https://path/to/foo.git",
+    )
+    assert _parse_pkg_spec("foo==1.2.3") == ("foo", "foo==1.2.3")
+
+
+def test_get_conda_envs_directory():
+    subprocess_output = mock.Mock()
+    subprocess_output.stdout = (
+        b"          package cache : /foo/bar/anaconda3/pkgs\n"
+        b"                          /foo/bar/.conda/pkgs\n"
+        b"       envs directories : /foo/bar/envs\n"
+        b"                          /Users/jklinger/.conda/envs\n"
+        b"               platform : osx-64"
+    )
+    assert get_conda_envs_directory(subprocess_output) == "/foo/bar/envs"

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -4,6 +4,7 @@ import os
 import subprocess
 import sys
 from contextlib import contextmanager
+from pathlib import Path
 from typing import Optional
 
 
@@ -42,11 +43,13 @@ def run_flow(
     environment: Optional[str] = None,
     batch: bool = False,
     python: str = sys.executable,
-) -> None:
+    extend_pythonpath: bool = True,
+) -> subprocess.CompletedProcess:
     """Run Metaflow at `path`."""
+    path = Path(path)
     cmd = [
         python,
-        str(path),
+        str(path.name),
         "--datastore",
         str(datastore),
         "--metadata",
@@ -62,11 +65,34 @@ def run_flow(
 
     cmd.append("run")
 
+    # DAPS projects need to be able to import {myproject}
+    # which we can figure out from the executable in this test.
+    # With that in mind, we specify PYTHONPATH here because {myproject}
+    # is not available at the point when daps_utils is imported.
+    env = dict(os.environ)
+    if extend_pythonpath:
+        pythonpath = str(path.parent.parent.parent) + ":" + env.get("PYTHONPATH", "")
+        env.update({"PYTHONPATH": pythonpath})
+
     try:
-        out = subprocess.run(cmd, capture_output=True, shell=False, check=True)
+        out = subprocess.run(
+            cmd, capture_output=True, shell=False, check=True, cwd=path.parent, env=env
+        )
     except subprocess.CalledProcessError as e:
         logging.error(e.args)
         logging.error(f"stdout:\n {e.stdout.decode()}")
         logging.error(f"stderr:\n {e.stderr.decode()}")
         raise e
     return out
+
+
+@contextmanager
+def env(**kwargs) -> None:
+    """Context Manager to change env variable."""
+    original = dict(os.environ)
+    try:
+        os.environ.update(kwargs)
+        yield
+    finally:
+        os.environ.clear()
+        os.environ.update(original)


### PR DESCRIPTION
Closes #20 

**Just a note up front: 11 out of 17 of the changed files are relating to testing so don't panic 😄 **

Introduces the following features:

* Any packages listed in the config under `PREINSTALL_PKGS` are installed for all batch tasks, so long as they are in the local environment. Packages are skipped if they're not in the local environment, meaning that switching off his behaviour is as simple as overwriting these variables.
* If script(s) `preinstall-{flow_name}.sh` and/or `preinstall-{flow_name}-{step_name}.sh` are present then they are executed prior to batch step execution.
* `daps-utils` and `mysql-connector-python` are defaults for `PREINSTALL_PKGS` as we would need them for all daps implementations at present. Happy to move this to daps only repos if preferred, but I would reiterate that these won't be installed unless `daps-utils` is already installed in the user's local env, which would kind of imply that you wanted to bundle these.

Originally I had intended that in the presence of `environment=conda` that `PREINSTALL_PKGS` wouldn't be installed however this wouldn't actually work in practice as e.g. `daps-utils` would still be needed at execution time. It is possible to implement this feature if you really think that it's desirable (it's just a few lines extra). Otherwise one minor workaround would be to toggle `PREINSTALL_PKGS` and use separate flows for packages that require `PREINSTALL_PKGS` and conda.

Additional integration tests
============================

Integration tests have been added for `batch_flow.py` and `batch_flow_with_conda.py` (described below). One caveat with this is that it increases test run time to 20 minutes(!) because batch tasks are submitted. One way to resolve this would be to set up a separate test matrix to allow for parallel testing, if that would be desirable?

How to check
============

* Make sure `daps-utils` and `mysql-connector-python` are installed in your working environment
* From `metaflow_extensions/tests/myproject/myproject/flows` run the following:

Integration 1: batch
--------------------

The following flow demonstrates that `daps-utils` is preinstalled also that the `preinstall-batch_flow.sh` script has run in the batch steps, both task prior to execution.

```
PYTHONPATH=~/Nesta/metaflow_extensions:~/Nesta/metaflow_extensions/tests/myproject python batch_flow.py --datastore=s3 run
```


Integration 2: batch + conda
----------------------------

The following flow demonstrates that `daps-utils` is preinstalled also that the `preinstall-batch_flow.sh` script has run in the batch steps, both task prior to execution. The special case here is that metaflow uses an additional set of pre-install mechanisms with conda and so the implementation is a little more involved.

```
PYTHONPATH=/path/to/metaflow_extensions:/path/to/metaflow_extensions/tests/myproject python batch_flow_with_conda.py --datastore=s3 --environment=conda run
```



